### PR TITLE
Changing config format to .toml

### DIFF
--- a/src/resource.cfg
+++ b/src/resource.cfg
@@ -1,9 +1,0 @@
-type: js
-
-main: server/main.js
-
-client-main: client/main.js,
-
-client-files: [	
-	"client/*"
-]

--- a/src/resource.toml
+++ b/src/resource.toml
@@ -1,0 +1,9 @@
+type = "js"
+
+main = "server/main.js"
+
+client-main = "client/main.js"
+
+client-files = [	
+	"client/*"
+]

--- a/src/resource.toml
+++ b/src/resource.toml
@@ -1,5 +1,7 @@
 type = "js"
 
+client-type = "js"
+
 main = "server/main.js"
 
 client-main = "client/main.js"


### PR DESCRIPTION
This fixxes #6 and basically only changes the config file format plus its content so that it fits the new format. There is btw no script for copy:meta which probably should've been for copying the config file?!

This also adds `client-type = "js"` just the ensure the right client module is used. I don't know if you want that, so if you don't, just tell me or remove it yourself. 